### PR TITLE
Implement Apollo sync worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# POC
+# Investor Codex
+
+This repository contains a proof-of-concept implementation for the Investor Codex platform. The goal is to mirror key features of commercial investment intelligence tools using open data sources and Azure OpenAI for enrichment.
+
+## Repository Layout
+
+* `backend/` contains two projects:
+  * **InvestorCodex.Api** – Minimal API used for experimentation
+  * **InvestorCodex.SyncService** – Worker service that syncs companies and contacts from Apollo into PostgreSQL
+* `frontend/` – Placeholder for a future Next.js application
+* `docs/` – Project documentation including the full functional specification
+
+The project is at an early stage and currently only includes minimal scaffolding.
+

--- a/backend/InvestorCodex.Api/Controllers/CompaniesController.cs
+++ b/backend/InvestorCodex.Api/Controllers/CompaniesController.cs
@@ -1,0 +1,24 @@
+using InvestorCodex.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InvestorCodex.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CompaniesController : ControllerBase
+{
+    // In-memory list to illustrate concept
+    private static readonly List<Company> Companies = new();
+
+    [HttpGet]
+    public ActionResult<IEnumerable<Company>> Get() => Companies;
+
+    [HttpPost]
+    public ActionResult<Company> Post([FromBody] Company company)
+    {
+        company.Id = Guid.NewGuid();
+        Companies.Add(company);
+        return CreatedAtAction(nameof(Get), new { id = company.Id }, company);
+    }
+}
+

--- a/backend/InvestorCodex.Api/Models/Company.cs
+++ b/backend/InvestorCodex.Api/Models/Company.cs
@@ -1,0 +1,13 @@
+namespace InvestorCodex.Api.Models;
+
+public class Company
+{
+    public Guid Id { get; set; }
+    public string? Name { get; set; }
+    public string? Domain { get; set; }
+    public string? Industry { get; set; }
+    public int? Headcount { get; set; }
+    public string? FundingStage { get; set; }
+    public string? Summary { get; set; }
+}
+

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();
+

--- a/backend/InvestorCodex.SyncService/ApolloSyncWorker.cs
+++ b/backend/InvestorCodex.SyncService/ApolloSyncWorker.cs
@@ -1,0 +1,54 @@
+using InvestorCodex.SyncService.Data;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace InvestorCodex.SyncService;
+
+/// <summary>
+/// Worker service that fetches company and contact data from Apollo and stores
+/// it in PostgreSQL. Failures are logged to CosmosDB. Runs once per day.
+/// </summary>
+
+public class ApolloSyncWorker : BackgroundService
+{
+    private readonly ApolloClient _client;
+    private readonly CompanyRepository _companies;
+    private readonly ContactRepository _contacts;
+    private readonly SyncFailureLogger _failureLogger;
+    private readonly ILogger<ApolloSyncWorker> _logger;
+
+    public ApolloSyncWorker(
+        ApolloClient client,
+        CompanyRepository companies,
+        ContactRepository contacts,
+        SyncFailureLogger failureLogger,
+        ILogger<ApolloSyncWorker> logger)
+    {
+        _client = client;
+        _companies = companies;
+        _contacts = contacts;
+        _failureLogger = failureLogger;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var timer = new PeriodicTimer(TimeSpan.FromHours(24));
+        do
+        {
+            try
+            {
+                var companies = await _client.FetchCompaniesAsync(stoppingToken);
+                await _companies.UpsertAsync(companies, stoppingToken);
+
+                var contacts = await _client.FetchContactsAsync(stoppingToken);
+                await _contacts.UpsertAsync(contacts, stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Apollo sync failed");
+                await _failureLogger.LogFailureAsync(ex, stoppingToken);
+            }
+        } while (await timer.WaitForNextTickAsync(stoppingToken));
+    }
+}

--- a/backend/InvestorCodex.SyncService/Data/ApolloClient.cs
+++ b/backend/InvestorCodex.SyncService/Data/ApolloClient.cs
@@ -1,0 +1,35 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using InvestorCodex.SyncService.Models;
+
+namespace InvestorCodex.SyncService.Data;
+
+public class ApolloClient
+{
+    private readonly HttpClient _http;
+    private readonly string _apiKey;
+
+    public ApolloClient(HttpClient http, IConfiguration config)
+    {
+        _http = http;
+        _apiKey = config["APOLLO_API_KEY"] ?? string.Empty;
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+    }
+
+    public async Task<IEnumerable<Company>> FetchCompaniesAsync(CancellationToken ct)
+    {
+        var resp = await _http.GetAsync("https://api.apollo.io/v1/companies/search", ct);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadAsStringAsync(ct);
+        // TODO: parse according to real schema
+        return JsonSerializer.Deserialize<List<Company>>(json) ?? [];
+    }
+
+    public async Task<IEnumerable<Contact>> FetchContactsAsync(CancellationToken ct)
+    {
+        var resp = await _http.GetAsync("https://api.apollo.io/v1/people/search", ct);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadAsStringAsync(ct);
+        return JsonSerializer.Deserialize<List<Contact>>(json) ?? [];
+    }
+}

--- a/backend/InvestorCodex.SyncService/Data/CompanyRepository.cs
+++ b/backend/InvestorCodex.SyncService/Data/CompanyRepository.cs
@@ -1,0 +1,27 @@
+using Dapper;
+using InvestorCodex.SyncService.Models;
+using Npgsql;
+
+namespace InvestorCodex.SyncService.Data;
+
+public class CompanyRepository
+{
+    private readonly string _connectionString;
+
+    public CompanyRepository(IConfiguration config)
+    {
+        _connectionString = config.GetConnectionString("Postgres") ?? string.Empty;
+    }
+
+    public async Task UpsertAsync(IEnumerable<Company> companies, CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        foreach (var c in companies)
+        {
+            const string sql = @"INSERT INTO companies (name, domain, industry, headcount, funding_stage)
+VALUES (@Name, @Domain, @Industry, @Headcount, @FundingStage)
+ON CONFLICT (domain) DO UPDATE SET industry = EXCLUDED.industry, headcount = EXCLUDED.headcount, funding_stage = EXCLUDED.funding_stage";
+            await conn.ExecuteAsync(new CommandDefinition(sql, c, cancellationToken: ct));
+        }
+    }
+}

--- a/backend/InvestorCodex.SyncService/Data/ContactRepository.cs
+++ b/backend/InvestorCodex.SyncService/Data/ContactRepository.cs
@@ -1,0 +1,27 @@
+using Dapper;
+using InvestorCodex.SyncService.Models;
+using Npgsql;
+
+namespace InvestorCodex.SyncService.Data;
+
+public class ContactRepository
+{
+    private readonly string _connectionString;
+
+    public ContactRepository(IConfiguration config)
+    {
+        _connectionString = config.GetConnectionString("Postgres") ?? string.Empty;
+    }
+
+    public async Task UpsertAsync(IEnumerable<Contact> contacts, CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        foreach (var c in contacts)
+        {
+            const string sql = @"INSERT INTO contacts (name, title, email, linkedin)
+VALUES (@Name, @Title, @Email, @LinkedInUrl)
+ON CONFLICT (email) DO UPDATE SET title = EXCLUDED.title, linkedin = EXCLUDED.linkedin";
+            await conn.ExecuteAsync(new CommandDefinition(sql, c, cancellationToken: ct));
+        }
+    }
+}

--- a/backend/InvestorCodex.SyncService/Data/SyncFailureLogger.cs
+++ b/backend/InvestorCodex.SyncService/Data/SyncFailureLogger.cs
@@ -1,0 +1,21 @@
+using Microsoft.Azure.Cosmos;
+
+namespace InvestorCodex.SyncService.Data;
+
+public class SyncFailureLogger
+{
+    private readonly Container _container;
+
+    public SyncFailureLogger(IConfiguration config)
+    {
+        var conn = config.GetConnectionString("Cosmos") ?? string.Empty;
+        var client = new CosmosClient(conn);
+        _container = client.GetContainer("investor-codex", "sync_failures");
+    }
+
+    public async Task LogFailureAsync(Exception ex, CancellationToken ct)
+    {
+        var doc = new { id = Guid.NewGuid().ToString(), message = ex.Message, stack = ex.StackTrace, timestamp = DateTime.UtcNow };
+        await _container.CreateItemAsync(doc, cancellationToken: ct);
+    }
+}

--- a/backend/InvestorCodex.SyncService/Models/Company.cs
+++ b/backend/InvestorCodex.SyncService/Models/Company.cs
@@ -1,0 +1,9 @@
+namespace InvestorCodex.SyncService.Models;
+
+public record Company(
+    string Name,
+    string Domain,
+    string? Industry,
+    int? Headcount,
+    string? FundingStage
+);

--- a/backend/InvestorCodex.SyncService/Models/Contact.cs
+++ b/backend/InvestorCodex.SyncService/Models/Contact.cs
@@ -1,0 +1,8 @@
+namespace InvestorCodex.SyncService.Models;
+
+public record Contact(
+    string Name,
+    string Title,
+    string? Email,
+    string? LinkedInUrl
+);

--- a/backend/InvestorCodex.SyncService/Program.cs
+++ b/backend/InvestorCodex.SyncService/Program.cs
@@ -1,0 +1,17 @@
+using InvestorCodex.SyncService;
+using InvestorCodex.SyncService.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        services.AddHttpClient<ApolloClient>();
+        services.AddSingleton<CompanyRepository>();
+        services.AddSingleton<ContactRepository>();
+        services.AddSingleton<SyncFailureLogger>();
+        services.AddHostedService<ApolloSyncWorker>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/docs/FSD.md
+++ b/docs/FSD.md
@@ -1,0 +1,37 @@
+# Investor Codex Functional Specification (v1.0)
+
+This document outlines the key features and components of the Investor Codex platform. It mirrors the full specification provided in the project planning stages and acts as a reference for contributors.
+
+---
+
+## Tech Stack Overview
+
+- **Frontend**: React, TypeScript, Tailwind (Next.js)
+- **Backend**: .NET 8 / ASP.NET Core Web API
+- **Database**: PostgreSQL, CosmosDB
+- **AI**: Azure OpenAI GPT-4o and embeddings
+- **Vector Search**: Azure Cognitive Search
+- **Auth**: Azure AD B2C
+
+## Core Modules
+
+1. **Company Intelligence**
+   - Pull company data from Apollo.io and enrich it using Azure OpenAI.
+   - Stored fields include name, industry, location and AI-generated summary, tags and risk flags.
+2. **Contact Intelligence**
+   - Similar enrichment for key contacts with persona classification.
+3. **Investment History**
+   - ETL jobs aggregate funding rounds and public filings from multiple sources.
+4. **Signal Tracking**
+   - Tracks real-time signals such as funding, hiring or risk events.
+5. **Similar Company Search**
+   - Embedding based search using Azure Cognitive Search.
+6. **Dashboard Frontend**
+   - Next.js powered user interface to browse companies, alerts and export data.
+
+Refer to the original functional specification for detailed schema and milestone breakdown.
+
+## Worker Services
+
+- **Apollo Sync Service** – A .NET 8 worker that runs daily to fetch companies and contacts from Apollo's `/companies/search` and `/people/search` endpoints. Records are upserted into PostgreSQL and any failures are logged to a CosmosDB `sync_failures` container.
+


### PR DESCRIPTION
## Summary
- document new worker service in FSD and README
- add `InvestorCodex.SyncService` with Apollo API sync skeleton
- store records to PostgreSQL and log failures to CosmosDB

## Testing
- `dotnet test ./backend/InvestorCodex.Api` *(fails: command not found)*
- `npm test --prefix frontend` *(fails: no package.json)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68409f2218d88332915663744ca68c9d