### PR TITLE
Add API configuration screen in Next.js demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository contains a proof-of-concept implementation for the Investor Code
   * **InvestorCodex.Api** – Minimal API used for experimentation
   * **InvestorCodex.SyncService** – Worker service that syncs companies and contacts from Apollo into PostgreSQL
   * **InvestmentFilingETL** – Python scripts that collect and enrich public investment filings
-* `frontend/` – Placeholder for a future Next.js application
+* `frontend/` – Minimal Next.js app demonstrating the dashboard
+  * Includes an **API Configuration** screen under `/api-config`
 * `docs/` – Project documentation including the full functional specification
 
 The project is at an early stage and currently only includes minimal scaffolding.

--- a/docs/FSD.md
+++ b/docs/FSD.md
@@ -74,6 +74,11 @@ The frontend is built with Next.js and Tailwind CSS. It consumes the backend API
 - `/alerts` – Timeline view of signals sorted by AI-assigned severity.
 - `/similar/:id` – Displays embedding based similar company results.
 - `/export` – Allows downloading PDF or CSV reports.
+- `/api-config` – Admin page for managing backend API endpoints.
+
+The **API Configuration** view lets administrators set base URLs or credentials
+for backend services (API, embedding, and enrichment). Settings are stored
+securely and used by the dashboard when making requests.
 
 ### User Roles
 

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "investor-codex-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5"
+  }
+}

--- a/frontend/pages/api-config.tsx
+++ b/frontend/pages/api-config.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+interface Config {
+  apiBaseUrl: string;
+  embeddingServiceUrl: string;
+  enrichmentFunctionUrl: string;
+}
+
+export default function ApiConfig() {
+  const [config, setConfig] = useState<Config>({
+    apiBaseUrl: '',
+    embeddingServiceUrl: '',
+    enrichmentFunctionUrl: '',
+  });
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setConfig({
+      ...config,
+      [e.target.name]: e.target.value,
+    });
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    alert('Configuration saved (placeholder).');
+  }
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>API Configuration</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: '30rem' }}>
+        <label>
+          API Base URL
+          <input name="apiBaseUrl" value={config.apiBaseUrl} onChange={handleChange} style={{ width: '100%' }} />
+        </label>
+        <label>
+          Embedding Service URL
+          <input name="embeddingServiceUrl" value={config.embeddingServiceUrl} onChange={handleChange} style={{ width: '100%' }} />
+        </label>
+        <label>
+          Enrichment Function URL
+          <input name="enrichmentFunctionUrl" value={config.enrichmentFunctionUrl} onChange={handleChange} style={{ width: '100%' }} />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+    </main>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Investor Codex Dashboard</h1>
+      <ul>
+        <li>
+          <Link href="/api-config">API Configuration</Link>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add skeleton Next.js app in `frontend/`
- implement `/api-config` page with form fields for backend URLs
- document API configuration screen in FSD and README

## Testing
- `npm install --ignore-scripts` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6840a72900c083329d05e4edf5b96f69