### PR TITLE
Use remote MCP feeds for context API

### DIFF
--- a/backend/InvestorCodex.Api/Configuration/ContextFeedSettings.cs
+++ b/backend/InvestorCodex.Api/Configuration/ContextFeedSettings.cs
@@ -1,0 +1,8 @@
+namespace InvestorCodex.Api.Configuration;
+
+public class ContextFeedSettings
+{
+    public const string SectionName = "ContextFeeds";
+
+    public Dictionary<string, string> Feeds { get; set; } = new();
+}

--- a/backend/InvestorCodex.Api/Controllers/ContextController.cs
+++ b/backend/InvestorCodex.Api/Controllers/ContextController.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using InvestorCodex.Api.Models;
+using InvestorCodex.Api.Services;
+
+namespace InvestorCodex.Api.Controllers;
+
+[ApiController]
+[Route("context")]
+public class ContextController : ControllerBase
+{
+    private readonly IContextFeedService _contextFeedService;
+    private readonly IWebHostEnvironment _env;
+
+    public ContextController(IContextFeedService contextFeedService, IWebHostEnvironment env)
+    {
+        _contextFeedService = contextFeedService;
+        _env = env;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<MCPContext>> Get([FromQuery(Name = "id")] string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return BadRequest("id query parameter required");
+        }
+
+        var context = await _contextFeedService.GetContextAsync(id);
+        if (context != null)
+        {
+            return Ok(context);
+        }
+
+        // fallback to sample data bundled with the app
+        var path = Path.Combine(_env.ContentRootPath, "Data", "context-sample.json");
+        if (System.IO.File.Exists(path))
+        {
+            var json = await System.IO.File.ReadAllTextAsync(path);
+            var dict = JsonSerializer.Deserialize<Dictionary<string, MCPContext>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (dict != null && dict.TryGetValue(id, out var sample))
+            {
+                return Ok(sample);
+            }
+        }
+
+        return NotFound();
+    }
+}

--- a/backend/InvestorCodex.Api/Data/context-sample.json
+++ b/backend/InvestorCodex.Api/Data/context-sample.json
@@ -1,0 +1,36 @@
+{
+  "vc-latest": {
+    "id": "vc-latest",
+    "title": "Latest VC News",
+    "timestamp": "2024-06-04T12:00:00Z",
+    "entries": [
+      {
+        "id": "1",
+        "headline": "FinTechCo secures $20M Series B",
+        "summary": "FinTechCo raises new funding to expand operations.",
+        "link": "https://technews.com/fintech-series-b",
+        "publishedAt": "2024-06-04T10:00:00Z",
+        "source": "TechNews",
+        "topics": ["funding", "fintech"],
+        "confidence": 0.9
+      }
+    ]
+  },
+  "investor-weekly": {
+    "id": "investor-weekly",
+    "title": "Weekly Investor Briefs",
+    "timestamp": "2024-06-03T08:00:00Z",
+    "entries": [
+      {
+        "id": "2",
+        "headline": "AIHealth raises $50M for clinical trials platform",
+        "summary": "AIHealth's latest round led by Health Ventures.",
+        "link": "https://healthnews.com/aihealth",
+        "publishedAt": "2024-06-02T07:00:00Z",
+        "source": "HealthNews",
+        "topics": ["healthcare", "ai", "funding"],
+        "confidence": 0.85
+      }
+    ]
+  }
+}

--- a/backend/InvestorCodex.Api/InvestorCodex.Api.csproj
+++ b/backend/InvestorCodex.Api/InvestorCodex.Api.csproj
@@ -18,4 +18,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Data\context-sample.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/backend/InvestorCodex.Api/Models/MCPContext.cs
+++ b/backend/InvestorCodex.Api/Models/MCPContext.cs
@@ -1,0 +1,9 @@
+namespace InvestorCodex.Api.Models;
+
+public class MCPContext
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; }
+    public List<MCPEntry> Entries { get; set; } = new();
+}

--- a/backend/InvestorCodex.Api/Models/MCPEntry.cs
+++ b/backend/InvestorCodex.Api/Models/MCPEntry.cs
@@ -1,0 +1,13 @@
+namespace InvestorCodex.Api.Models;
+
+public class MCPEntry
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Headline { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public string Link { get; set; } = string.Empty;
+    public DateTime PublishedAt { get; set; }
+    public string Source { get; set; } = string.Empty;
+    public List<string> Topics { get; set; } = new();
+    public double Confidence { get; set; }
+}

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -15,10 +15,13 @@ builder.Services.Configure<ApolloSettings>(
     builder.Configuration.GetSection(ApolloSettings.SectionName));
 builder.Services.Configure<TwitterAPISettings>(
     builder.Configuration.GetSection(TwitterAPISettings.SectionName));
+builder.Services.Configure<ContextFeedSettings>(
+    builder.Configuration.GetSection(ContextFeedSettings.SectionName));
 
 // Add HTTP clients for external services
 builder.Services.AddHttpClient<IApolloService, ApolloService>();
 builder.Services.AddHttpClient<ITwitterService, TwitterService>();
+builder.Services.AddHttpClient<IContextFeedService, ContextFeedService>();
 
 // Add repository services
 builder.Services.AddScoped<ICompanyRepository, CompanyRepository>();
@@ -29,6 +32,7 @@ builder.Services.AddScoped<ISignalRepository, SignalRepository>();
 // Add external API services
 builder.Services.AddScoped<IApolloService, ApolloService>();
 builder.Services.AddScoped<ITwitterService, TwitterService>();
+builder.Services.AddScoped<IContextFeedService, ContextFeedService>();
 
 // Add services to the container
 builder.Services.AddControllers();

--- a/backend/InvestorCodex.Api/Services/ContextFeedService.cs
+++ b/backend/InvestorCodex.Api/Services/ContextFeedService.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using InvestorCodex.Api.Configuration;
+using InvestorCodex.Api.Models;
+using Microsoft.Extensions.Options;
+
+namespace InvestorCodex.Api.Services;
+
+public interface IContextFeedService
+{
+    Task<MCPContext?> GetContextAsync(string id);
+}
+
+public class ContextFeedService : IContextFeedService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ContextFeedSettings _settings;
+    private readonly ILogger<ContextFeedService> _logger;
+
+    public ContextFeedService(HttpClient httpClient, IOptions<ContextFeedSettings> settings, ILogger<ContextFeedService> logger)
+    {
+        _httpClient = httpClient;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public async Task<MCPContext?> GetContextAsync(string id)
+    {
+        if (!_settings.Feeds.TryGetValue(id, out var url))
+        {
+            _logger.LogWarning("No feed URL configured for context id {Id}", id);
+            return null;
+        }
+
+        try
+        {
+            var response = await _httpClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Context feed HTTP {Status} for {Id}", response.StatusCode, id);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var context = JsonSerializer.Deserialize<MCPContext>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (context != null)
+            {
+                return context;
+            }
+
+            var dict = JsonSerializer.Deserialize<Dictionary<string, MCPContext>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (dict != null && dict.TryGetValue(id, out var ctx))
+            {
+                return ctx;
+            }
+
+            _logger.LogWarning("Context feed did not contain expected data for {Id}", id);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching context feed {Id}", id);
+            return null;
+        }
+    }
+}

--- a/backend/InvestorCodex.Api/appsettings.Development.json
+++ b/backend/InvestorCodex.Api/appsettings.Development.json
@@ -19,5 +19,9 @@
     "ApiKey": "Kt8Bg1eDCHIK0BwxLYDB6VH1y",
     "ApiSecret": "b47Bc8CQRiwoiyqFmngq8GJ9cpUTi8VOV8nzUOrlpPShkjQYNd",
     "BearerToken": "AAAAAAAAAAAAAAAAAAAAAGcf2QEAAAAAhWC0%2B50Re7UP6BfNGJn%2Bk%2Bx8Sos%3D8UYFuZ9Q4sR8bHnETXUUueZjzFMiCsgYIAXW0eqgFYYMuWEnnf"
+  },
+  "ContextFeeds": {
+    "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
+    "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
   }
 }

--- a/backend/InvestorCodex.Api/appsettings.json
+++ b/backend/InvestorCodex.Api/appsettings.json
@@ -21,5 +21,9 @@
     "ApiKey": "Kt8Bg1eDCHIK0BwxLYDB6VH1y",
     "ApiSecret": "b47Bc8CQRiwoiyqFmngq8GJ9cpUTi8VOV8nzUOrlpPShkjQYNd",
     "BearerToken": "AAAAAAAAAAAAAAAAAAAAAGcf2QEAAAAAhWC0%2B50Re7UP6BfNGJn%2Bk%2Bx8Sos%3D8UYFuZ9Q4sR8bHnETXUUueZjzFMiCsgYIAXW0eqgFYYMuWEnnf"
+  },
+  "ContextFeeds": {
+    "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
+    "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
   }
 }

--- a/docs/FSD.md
+++ b/docs/FSD.md
@@ -33,6 +33,7 @@ Investor Codex is a full-stack, AI-powered investment intelligence platform aimi
 * Apollo.io
 * Public filings (SEC, SEDAR+, CIRO)
 * Crunchbase, YahooFinance, GNews, TechCrunch (via MCP)
+* Twitter API for additional signal monitoring
 * Internal annotations and manual enrichment
 
 ---
@@ -62,6 +63,7 @@ Investor Codex is a full-stack, AI-powered investment intelligence platform aimi
 ### 4.4 Signal Detection & Alerting
 
 * Alerts extracted via NLP from filings and news
+* TwitterService polls recent tweets for funding and acquisition chatter
 * Smart categorization: hiring, leadership change, risk flags
 * Alert scoring (0-1 confidence)
 * Displayed in `/alerts` dashboard
@@ -128,6 +130,7 @@ Investor Codex is a full-stack, AI-powered investment intelligence platform aimi
 
 * `GET /context?id=vc-latest`
 * `GET /context?id=investor-weekly`
+  * Returns an `MCPContext` JSON payload retrieved from the configured MCP feed (with a local sample fallback)
 
 ---
 
@@ -147,8 +150,8 @@ Investor Codex is a full-stack, AI-powered investment intelligence platform aimi
 ### AppSettings (web.config / appsettings.json)
 
 ```xml
-<add key="VCContextFeedUrl" value="https://mcp.investorcodex.ai/context?id=vc-latest" />
-<add key="InvestorBriefsFeedUrl" value="https://mcp.investorcodex.ai/context?id=investor-weekly" />
+<add key="ContextFeeds:vc-latest" value="https://mcp.investorcodex.ai/context?id=vc-latest" />
+<add key="ContextFeeds:investor-weekly" value="https://mcp.investorcodex.ai/context?id=investor-weekly" />
 <add key="ApolloApiKey" value="live_apollo_api_key_goes_here" />
 <add key="OpenAI__Endpoint" value="https://your-openai-instance.openai.azure.com/" />
 <add key="OpenAI__Key" value="live_openai_api_key_goes_here" />
@@ -158,6 +161,9 @@ Investor Codex is a full-stack, AI-powered investment intelligence platform aimi
 <add key="VectorSearchIndex" value="investor-index" />
 <add key="VectorSearchKey" value="live_vector_search_key_here" />
 <add key="DatabaseConnection" value="Host=localhost;Port=5432;Database=InvestorCodex;Username=postgres;Password=your_password" />
+<add key="TwitterApiKey" value="your-twitter-api-key" />
+<add key="TwitterApiSecret" value="your-twitter-api-secret" />
+<add key="TwitterBearerToken" value="your-twitter-bearer" />
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add configurable ContextFeed service for live MCP context feeds
- update ContextController to use new service with sample fallback
- wire up ContextFeeds settings and HTTP client in Program.cs
- document new settings and behavior in FSD

## Testing
- `dotnet build backend/InvestorCodex.Api/InvestorCodex.Api.csproj -nologo` *(fails: command not found)*
- `pwsh ./test-simple.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846e3ecf59083329e47baf370112d20