### PR TITLE
Add NLWeb page and context types

### DIFF
--- a/frontend/app/nlweb/page.tsx
+++ b/frontend/app/nlweb/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { contextApi } from '@/lib/api';
+import type { MCPEntry } from '@/types';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import NewsCard from '@/components/ui/NewsCard';
+
+export default function NLWebPage() {
+  const [entries, setEntries] = useState<MCPEntry[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      try {
+        const ctx = await contextApi.get('vc-latest');
+        if (isMounted) setEntries(ctx.entries);
+      } catch (err) {
+        console.error('Failed to load context', err);
+      }
+    };
+
+    load();
+    const interval = setInterval(load, 60 * 60 * 1000);
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <ProtectedRoute>
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">News & Context</h1>
+            <p className="text-gray-600">Latest venture capital headlines</p>
+          </div>
+          <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+            {entries.map((e) => (
+              <NewsCard key={e.id} entry={e} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -13,11 +13,13 @@ import {
   XMarkIcon,
   HomeIcon,
   DocumentTextIcon,
-  Cog6ToothIcon
+  Cog6ToothIcon,
+  NewspaperIcon
 } from '@heroicons/react/24/outline';
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: HomeIcon },
+  { name: 'NLWeb', href: '/nlweb', icon: NewspaperIcon },
   { name: 'Companies', href: '/companies', icon: BuildingOfficeIcon },
   { name: 'Search', href: '/search', icon: MagnifyingGlassIcon },
   { name: 'Signals', href: '/alerts', icon: BellIcon },

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   XMarkIcon,
   Squares2X2Icon,
   Cog6ToothIcon,
+  NewspaperIcon,
 } from '@heroicons/react/24/outline';
 
 interface SidebarProps {
@@ -21,6 +22,7 @@ interface SidebarProps {
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: Squares2X2Icon },
+  { name: 'NLWeb', href: '/nlweb', icon: NewspaperIcon },
   { name: 'Companies', href: '/companies', icon: BuildingOfficeIcon },
   { name: 'Alerts', href: '/alerts', icon: ExclamationTriangleIcon },
   { name: 'Search', href: '/search', icon: MagnifyingGlassIcon },

--- a/frontend/src/components/ui/NewsCard.tsx
+++ b/frontend/src/components/ui/NewsCard.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from './Card';
+import type { MCPEntry } from '@/types';
+
+interface NewsCardProps {
+  entry: MCPEntry;
+}
+
+export default function NewsCard({ entry }: NewsCardProps) {
+  return (
+    <Card className="hover:shadow-md">
+      <CardHeader>
+        <CardTitle>{entry.headline}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-gray-600 mb-4">{entry.summary}</p>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-gray-500">{entry.source}</span>
+          <Link
+            href={entry.link}
+            target="_blank"
+            className="text-blue-600 hover:underline"
+          >
+            Read more
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -9,6 +9,7 @@ import type {
   ExportRequest,
   ExportJob,
   SimilarCompany,
+  MCPContext,
 } from '@/types';
 
 export const companiesApi = {
@@ -157,4 +158,8 @@ export const contactsApi = {
 
   delete: (id: string): Promise<void> =>
     api.delete(`/api/contacts/${id}`),
+};
+
+export const contextApi = {
+  get: (id: string): Promise<MCPContext> => api.get(`/context?id=${id}`),
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -144,3 +144,21 @@ export interface AuthUser {
   accessToken: string;
   refreshToken?: string;
 }
+
+export interface MCPEntry {
+  id: string;
+  headline: string;
+  summary: string;
+  link: string;
+  publishedAt: string;
+  source: string;
+  topics: string[];
+  confidence: number;
+}
+
+export interface MCPContext {
+  id: string;
+  title: string;
+  timestamp: string;
+  entries: MCPEntry[];
+}


### PR DESCRIPTION
## Summary
- define `MCPEntry` and `MCPContext` types
- expose `contextApi.get()` in the API client
- add `NewsCard` UI component
- implement `/nlweb` page fetching `vc-latest` context
- link NLWeb page in Navigation and Sidebar

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a1dcb03d88332a6beac0500dd027a