### PR TITLE
Update frontend path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a proof-of-concept implementation for the Investor Code
   * **InvestorCodex.SyncService** – Worker service that syncs companies and contacts from Apollo into PostgreSQL
   * **InvestmentFilingETL** – Python scripts that collect and enrich public investment filings
 * `frontend/` – Minimal Next.js app demonstrating the dashboard
-  * Includes an **API Configuration** screen under `/api-config`
+  * Includes an **API Configuration** screen under `/settings`
 * `docs/` – Project documentation including the full functional specification
 
 The project is at an early stage and currently only includes minimal scaffolding.


### PR DESCRIPTION
## Summary
- reference `/settings` page instead of `/api-config`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_684a2abdb6a08332bbf055e8db5f070c