### PR TITLE
Implement admin settings API

### DIFF
--- a/backend/InvestorCodex.Api/Controllers/SettingsController.cs
+++ b/backend/InvestorCodex.Api/Controllers/SettingsController.cs
@@ -1,0 +1,30 @@
+using InvestorCodex.Api.Models;
+using InvestorCodex.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InvestorCodex.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SettingsController : ControllerBase
+{
+    private readonly ISettingsService _service;
+
+    public SettingsController(ISettingsService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public ActionResult<SettingsDto> Get()
+    {
+        return Ok(_service.GetSettings());
+    }
+
+    [HttpPut]
+    public IActionResult Update([FromBody] SettingsDto dto)
+    {
+        _service.UpdateSettings(dto);
+        return NoContent();
+    }
+}

--- a/backend/InvestorCodex.Api/Models/SettingsDto.cs
+++ b/backend/InvestorCodex.Api/Models/SettingsDto.cs
@@ -1,0 +1,16 @@
+using InvestorCodex.Api.Configuration;
+
+namespace InvestorCodex.Api.Models;
+
+public class SettingsDto
+{
+    public string ApolloApiKey { get; set; } = string.Empty;
+    public string ApolloBaseUrl { get; set; } = string.Empty;
+    public string TwitterApiKey { get; set; } = string.Empty;
+    public string TwitterApiSecret { get; set; } = string.Empty;
+    public string TwitterBearerToken { get; set; } = string.Empty;
+    public string OpenAIEndpoint { get; set; } = string.Empty;
+    public string OpenAIApiKey { get; set; } = string.Empty;
+    public string OpenAIModel { get; set; } = string.Empty;
+    public string DbConnectionString { get; set; } = string.Empty;
+}

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -18,6 +18,10 @@ builder.Services.Configure<TwitterAPISettings>(
 builder.Services.Configure<ContextFeedSettings>(
     builder.Configuration.GetSection(ContextFeedSettings.SectionName));
 
+// In-memory settings storage
+builder.Services.AddSingleton<ISettingsService>(sp =>
+    new InMemorySettingsService(sp.GetRequiredService<IConfiguration>()));
+
 // Add HTTP clients for external services
 builder.Services.AddHttpClient<IApolloService, ApolloService>();
 builder.Services.AddHttpClient<ITwitterService, TwitterService>();

--- a/backend/InvestorCodex.Api/Services/SettingsService.cs
+++ b/backend/InvestorCodex.Api/Services/SettingsService.cs
@@ -1,0 +1,38 @@
+using InvestorCodex.Api.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace InvestorCodex.Api.Services;
+
+public interface ISettingsService
+{
+    SettingsDto GetSettings();
+    void UpdateSettings(SettingsDto newSettings);
+}
+
+public class InMemorySettingsService : ISettingsService
+{
+    private SettingsDto _settings;
+
+    public InMemorySettingsService(IConfiguration configuration)
+    {
+        _settings = new SettingsDto
+        {
+            ApolloApiKey = configuration["Apollo:ApiKey"] ?? string.Empty,
+            ApolloBaseUrl = configuration["Apollo:BaseUrl"] ?? string.Empty,
+            TwitterApiKey = configuration["TwitterAPI:ApiKey"] ?? string.Empty,
+            TwitterApiSecret = configuration["TwitterAPI:ApiSecret"] ?? string.Empty,
+            TwitterBearerToken = configuration["TwitterAPI:BearerToken"] ?? string.Empty,
+            OpenAIEndpoint = configuration["AdvantageAI:Url"] ?? string.Empty,
+            OpenAIApiKey = configuration["AdvantageAI:Key"] ?? string.Empty,
+            OpenAIModel = configuration["AdvantageAI:Model"] ?? string.Empty,
+            DbConnectionString = configuration.GetConnectionString("DefaultConnection") ?? string.Empty
+        };
+    }
+
+    public SettingsDto GetSettings() => _settings;
+
+    public void UpdateSettings(SettingsDto newSettings)
+    {
+        _settings = newSettings;
+    }
+}

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -161,16 +161,35 @@ export default function SettingsPage() {
   ]);
 
   useEffect(() => {
-    // Initialize masked fields
-    const initialMaskedFields = new Set<string>();
-    services.forEach(service => {
-      service.fields.forEach(field => {
-        if (field.masked) {
-          initialMaskedFields.add(`${service.name}_${field.key}`);
+    const loadSettings = async () => {
+      try {
+        const res = await fetch('/api/settings');
+        if (res.ok) {
+          const data = await res.json();
+          const updatedServices = services.map((service) => ({
+            ...service,
+            fields: service.fields.map((field) => ({
+              ...field,
+              value: data[field.key] ?? field.value,
+            })),
+          }));
+
+          const initialMaskedFields = new Set<string>();
+          updatedServices.forEach((s) => {
+            s.fields.forEach((f) => {
+              if (f.masked) initialMaskedFields.add(`${s.name}_${f.key}`);
+            });
+          });
+
+          setServices(updatedServices);
+          setMaskedFields(initialMaskedFields);
         }
-      });
-    });
-    setMaskedFields(initialMaskedFields);
+      } catch (err) {
+        console.error('Failed to load settings', err);
+      }
+    };
+
+    loadSettings();
   }, []);
 
   const getStatusIcon = (status: string) => {
@@ -257,9 +276,23 @@ export default function SettingsPage() {
   const saveConfiguration = async () => {
     try {
       setLoading(true);
-      // TODO: Implement real API call to save configuration
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
-      
+      const payload: Record<string, string> = {};
+      services.forEach((service) => {
+        service.fields.forEach((field) => {
+          payload[field.key] = field.value;
+        });
+      });
+
+      const res = await fetch('/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to save');
+      }
+
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (error) {


### PR DESCRIPTION
## Summary
- add backend API for saving settings
- wire up Settings page to use `/api/settings`

## Testing
- `npm run lint` *(fails: next not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a2ac54c0c8332a59e18c47f969f77