### PR TITLE
Load API keys from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,21 @@ This repository contains a proof-of-concept implementation for the Investor Code
 
 The project is at an early stage and currently only includes minimal scaffolding.
 
+## Configuration
+
+The API expects several credentials to be supplied via environment variables or
+your preferred secrets manager. The following variables are required:
+
+```
+ADVANTAGEAI__URL=<Azure OpenAI endpoint>
+ADVANTAGEAI__KEY=<Azure OpenAI key>
+ADVANTAGEAI__MODEL=<Model name>
+APOLLO__APIKEY=<Apollo API key>
+APOLLO__BASEURL=<Apollo base URL>
+TWITTERAPI__APIKEY=<Twitter API key>
+TWITTERAPI__APISECRET=<Twitter API secret>
+TWITTERAPI__BEARERTOKEN=<Twitter bearer token>
+```
+
+Ensure these are set before running the backend project.
+

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -8,6 +8,10 @@ using InvestorCodex.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Include environment variables so sensitive values can be supplied outside of
+// source control.
+builder.Configuration.AddEnvironmentVariables();
+
 // Add configuration settings
 builder.Services.Configure<AdvantageAISettings>(
     builder.Configuration.GetSection(AdvantageAISettings.SectionName));

--- a/backend/InvestorCodex.Api/appsettings.Development.json
+++ b/backend/InvestorCodex.Api/appsettings.Development.json
@@ -8,17 +8,17 @@
   "AllowedHosts": "*",
   "AdvantageAI": {
     "Url": "https://AdvantageAI.openai.azure.com/",
-    "Key": "6a49d2914c1b4066b1c7046feaa3f95a",
+    "Key": "",
     "Model": "gpt-4o"
   },
   "Apollo": {
-    "ApiKey": "Grxi_g98_sg9B0gwGmDnnA",
+    "ApiKey": "",
     "BaseUrl": "https://api.apollo.io/v1"
   },
   "TwitterAPI": {
-    "ApiKey": "Kt8Bg1eDCHIK0BwxLYDB6VH1y",
-    "ApiSecret": "b47Bc8CQRiwoiyqFmngq8GJ9cpUTi8VOV8nzUOrlpPShkjQYNd",
-    "BearerToken": "AAAAAAAAAAAAAAAAAAAAAGcf2QEAAAAAhWC0%2B50Re7UP6BfNGJn%2Bk%2Bx8Sos%3D8UYFuZ9Q4sR8bHnETXUUueZjzFMiCsgYIAXW0eqgFYYMuWEnnf"
+    "ApiKey": "",
+    "ApiSecret": "",
+    "BearerToken": ""
   },
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",

--- a/backend/InvestorCodex.Api/appsettings.json
+++ b/backend/InvestorCodex.Api/appsettings.json
@@ -14,17 +14,17 @@
   },
   "AdvantageAI": {
     "Url": "https://AdvantageAI.openai.azure.com/",
-    "Key": "6a49d2914c1b4066b1c7046feaa3f95a",
+    "Key": "",
     "Model": "gpt-4o"
   },
   "Apollo": {
-    "ApiKey": "Grxi_g98_sg9B0gwGmDnnA",
+    "ApiKey": "",
     "BaseUrl": "https://api.apollo.io/v1"
   },
   "TwitterAPI": {
-    "ApiKey": "Kt8Bg1eDCHIK0BwxLYDB6VH1y",
-    "ApiSecret": "b47Bc8CQRiwoiyqFmngq8GJ9cpUTi8VOV8nzUOrlpPShkjQYNd",
-    "BearerToken": "AAAAAAAAAAAAAAAAAAAAAGcf2QEAAAAAhWC0%2B50Re7UP6BfNGJn%2Bk%2Bx8Sos%3D8UYFuZ9Q4sR8bHnETXUUueZjzFMiCsgYIAXW0eqgFYYMuWEnnf"
+    "ApiKey": "",
+    "ApiSecret": "",
+    "BearerToken": ""
   },
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",


### PR DESCRIPTION
## Summary
- ensure backend reads environment variables
- strip API secrets from appsettings files
- document required environment variables

## Testing
- `dotnet build InvestorCodex.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684a2ac86a088332a0cb95e8012d9617