### PR TITLE
Add vector and storage settings

### DIFF
--- a/backend/InvestorCodex.Api/Configuration/ExternalServiceSettings.cs
+++ b/backend/InvestorCodex.Api/Configuration/ExternalServiceSettings.cs
@@ -20,9 +20,26 @@ namespace InvestorCodex.Api.Configuration
     public class TwitterAPISettings
     {
         public const string SectionName = "TwitterAPI";
-        
+
         public string ApiKey { get; set; } = string.Empty;
         public string ApiSecret { get; set; } = string.Empty;
         public string BearerToken { get; set; } = string.Empty;
+    }
+
+    public class VectorDbSettings
+    {
+        public const string SectionName = "VectorDb";
+
+        public string Endpoint { get; set; } = string.Empty;
+        public string Index { get; set; } = string.Empty;
+        public string Key { get; set; } = string.Empty;
+    }
+
+    public class BlobStorageSettings
+    {
+        public const string SectionName = "BlobStorage";
+
+        public string ConnectionString { get; set; } = string.Empty;
+        public string Container { get; set; } = string.Empty;
     }
 }

--- a/backend/InvestorCodex.Api/Configuration/RuntimeSettingsStore.cs
+++ b/backend/InvestorCodex.Api/Configuration/RuntimeSettingsStore.cs
@@ -1,0 +1,7 @@
+namespace InvestorCodex.Api.Configuration;
+
+public static class RuntimeSettingsStore
+{
+    public static VectorDbSettings VectorDb { get; set; } = new();
+    public static BlobStorageSettings BlobStorage { get; set; } = new();
+}

--- a/backend/InvestorCodex.Api/Controllers/SettingsController.cs
+++ b/backend/InvestorCodex.Api/Controllers/SettingsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using InvestorCodex.Api.Configuration;
+
+namespace InvestorCodex.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SettingsController : ControllerBase
+{
+    [HttpGet("vector-db")]
+    public ActionResult<VectorDbSettings> GetVectorDb()
+    {
+        return Ok(RuntimeSettingsStore.VectorDb);
+    }
+
+    [HttpPost("vector-db")]
+    public ActionResult SetVectorDb([FromBody] VectorDbSettings settings)
+    {
+        RuntimeSettingsStore.VectorDb = settings;
+        return Ok();
+    }
+
+    [HttpGet("blob-storage")]
+    public ActionResult<BlobStorageSettings> GetBlobStorage()
+    {
+        return Ok(RuntimeSettingsStore.BlobStorage);
+    }
+
+    [HttpPost("blob-storage")]
+    public ActionResult SetBlobStorage([FromBody] BlobStorageSettings settings)
+    {
+        RuntimeSettingsStore.BlobStorage = settings;
+        return Ok();
+    }
+}

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -17,6 +17,10 @@ builder.Services.Configure<TwitterAPISettings>(
     builder.Configuration.GetSection(TwitterAPISettings.SectionName));
 builder.Services.Configure<ContextFeedSettings>(
     builder.Configuration.GetSection(ContextFeedSettings.SectionName));
+builder.Services.Configure<VectorDbSettings>(
+    builder.Configuration.GetSection(VectorDbSettings.SectionName));
+builder.Services.Configure<BlobStorageSettings>(
+    builder.Configuration.GetSection(BlobStorageSettings.SectionName));
 
 // Add HTTP clients for external services
 builder.Services.AddHttpClient<IApolloService, ApolloService>();

--- a/backend/InvestorCodex.Api/appsettings.Development.json
+++ b/backend/InvestorCodex.Api/appsettings.Development.json
@@ -23,5 +23,14 @@
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
     "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
+  },
+  "VectorDb": {
+    "Endpoint": "",
+    "Index": "",
+    "Key": ""
+  },
+  "BlobStorage": {
+    "ConnectionString": "",
+    "Container": ""
   }
 }

--- a/backend/InvestorCodex.Api/appsettings.json
+++ b/backend/InvestorCodex.Api/appsettings.json
@@ -29,5 +29,14 @@
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
     "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
+  },
+  "VectorDb": {
+    "Endpoint": "",
+    "Index": "",
+    "Key": ""
+  },
+  "BlobStorage": {
+    "ConnectionString": "",
+    "Container": ""
   }
 }

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -17,6 +17,8 @@ import {
   CloudIcon,
   GlobeAltIcon,
   ChatBubbleLeftRightIcon,
+  CircleStackIcon,
+  ArchiveBoxIcon,
 } from '@heroicons/react/24/outline';
 
 interface ServiceConfig {
@@ -155,6 +157,64 @@ export default function SettingsPage() {
           placeholder: 'Host=localhost;Database=investorcodex;Username=postgres;Password=yourpassword',
           required: true,
           masked: true,
+        },
+      ],
+    },
+    {
+      name: 'Vector DB',
+      icon: <CircleStackIcon className="h-6 w-6" />,
+      description: 'Vector database for embeddings',
+      status: 'disconnected',
+      fields: [
+        {
+          key: 'vectordb_endpoint',
+          label: 'Endpoint',
+          type: 'url',
+          value: '',
+          placeholder: 'https://your-vectordb.com',
+          required: true,
+        },
+        {
+          key: 'vectordb_index',
+          label: 'Index',
+          type: 'text',
+          value: '',
+          placeholder: 'index name',
+          required: true,
+        },
+        {
+          key: 'vectordb_key',
+          label: 'API Key',
+          type: 'password',
+          value: '',
+          placeholder: 'Vector DB API key',
+          required: true,
+          masked: true,
+        },
+      ],
+    },
+    {
+      name: 'Blob Storage',
+      icon: <ArchiveBoxIcon className="h-6 w-6" />,
+      description: 'Azure Blob Storage for files',
+      status: 'disconnected',
+      fields: [
+        {
+          key: 'blob_connection_string',
+          label: 'Connection String',
+          type: 'password',
+          value: '',
+          placeholder: 'Azure Blob connection string',
+          required: true,
+          masked: true,
+        },
+        {
+          key: 'blob_container',
+          label: 'Container',
+          type: 'text',
+          value: '',
+          placeholder: 'container name',
+          required: true,
         },
       ],
     },


### PR DESCRIPTION
## Summary
- add VectorDbSettings and BlobStorageSettings
- store runtime configuration and expose SettingsController endpoints
- register new config sections in Program.cs and update appsettings
- extend settings page with Vector DB and Blob Storage fields

## Testing
- `npm run lint` *(fails: next not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a2acef4088332b4e69d7262f2e4ba