### PR TITLE
Fix README path for API settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a proof-of-concept implementation for the Investor Code
   * **InvestorCodex.SyncService** – Worker service that syncs companies and contacts from Apollo into PostgreSQL
   * **InvestmentFilingETL** – Python scripts that collect and enrich public investment filings
 * `frontend/` – Minimal Next.js app demonstrating the dashboard
-  * Includes an **API Configuration** screen under `/settings`
+  * Includes an **API Configuration** screen on the `/settings` page
 * `docs/` – Project documentation including the full functional specification
 
 The project is at an early stage and currently only includes minimal scaffolding.


### PR DESCRIPTION
## Summary
- correct README to refer to the `/settings` page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a2ba9738483328a511e0391c4f379