### PR TITLE
Implement export job endpoints

### DIFF
--- a/backend/InvestorCodex.Api/Configuration/ExportSettings.cs
+++ b/backend/InvestorCodex.Api/Configuration/ExportSettings.cs
@@ -1,0 +1,11 @@
+namespace InvestorCodex.Api.Configuration;
+
+public class ExportSettings
+{
+    public const string SectionName = "Export";
+
+    public string ServiceBusConnectionString { get; set; } = string.Empty;
+    public string QueueName { get; set; } = "export-jobs";
+    public string BlobConnectionString { get; set; } = string.Empty;
+    public string ContainerName { get; set; } = "exports";
+}

--- a/backend/InvestorCodex.Api/InvestorCodex.Api.csproj
+++ b/backend/InvestorCodex.Api/InvestorCodex.Api.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/InvestorCodex.Api/Models/Export.cs
+++ b/backend/InvestorCodex.Api/Models/Export.cs
@@ -10,6 +10,8 @@ public class ExportRequest
 
 public class ExportJob
 {
+    public string Type { get; set; } = "companies";
+    public string Format { get; set; } = "csv";
     public Guid Id { get; set; }
     public string Status { get; set; } = "pending"; // pending, processing, completed, failed
     public string? DownloadUrl { get; set; }

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -17,6 +17,8 @@ builder.Services.Configure<TwitterAPISettings>(
     builder.Configuration.GetSection(TwitterAPISettings.SectionName));
 builder.Services.Configure<ContextFeedSettings>(
     builder.Configuration.GetSection(ContextFeedSettings.SectionName));
+builder.Services.Configure<ExportSettings>(
+    builder.Configuration.GetSection(ExportSettings.SectionName));
 
 // Add HTTP clients for external services
 builder.Services.AddHttpClient<IApolloService, ApolloService>();
@@ -35,6 +37,7 @@ builder.Services.AddScoped<IApolloService, ApolloService>();
 builder.Services.AddScoped<ITwitterService, TwitterService>();
 builder.Services.AddScoped<IContextFeedService, ContextFeedService>();
 builder.Services.AddScoped<ISignalDetectionService, SignalDetectionService>();
+builder.Services.AddSingleton<IExportService, ExportService>();
 
 // Add services to the container
 builder.Services.AddControllers();

--- a/backend/InvestorCodex.Api/Services/ExportService.cs
+++ b/backend/InvestorCodex.Api/Services/ExportService.cs
@@ -1,0 +1,118 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Azure.Storage.Blobs;
+using Azure.Storage.Sas;
+using InvestorCodex.Api.Configuration;
+using InvestorCodex.Api.Models;
+using Microsoft.Extensions.Options;
+
+namespace InvestorCodex.Api.Services;
+
+public interface IExportService
+{
+    Task<ExportJob> QueueExportAsync(ExportRequest request);
+    Task<ExportJob?> GetJobAsync(Guid id);
+    Task<List<ExportJob>> GetJobsAsync();
+    Task<bool> DeleteJobAsync(Guid id);
+}
+
+public class ExportService : IExportService
+{
+    private readonly ServiceBusClient _busClient;
+    private readonly BlobContainerClient _container;
+    private readonly ConcurrentDictionary<Guid, ExportJob> _jobs = new();
+    private readonly ExportSettings _settings;
+
+    public ExportService(IOptions<ExportSettings> settings)
+    {
+        _settings = settings.Value;
+        _busClient = new ServiceBusClient(_settings.ServiceBusConnectionString);
+        _container = new BlobContainerClient(_settings.BlobConnectionString, _settings.ContainerName);
+        _container.CreateIfNotExists();
+    }
+
+    public async Task<ExportJob> QueueExportAsync(ExportRequest request)
+    {
+        var job = new ExportJob
+        {
+            Id = Guid.NewGuid(),
+            Status = "pending",
+            CreatedAt = DateTime.UtcNow,
+            Format = request.Format,
+            Type = request.Type
+        };
+
+        _jobs[job.Id] = job;
+
+        var sender = _busClient.CreateSender(_settings.QueueName);
+        var payload = JsonSerializer.Serialize(new { JobId = job.Id, Request = request });
+        await sender.SendMessageAsync(new ServiceBusMessage(payload));
+
+        return job;
+    }
+
+    public async Task<ExportJob?> GetJobAsync(Guid id)
+    {
+        if (!_jobs.TryGetValue(id, out var job))
+            return null;
+
+        await UpdateStatusAsync(job);
+        return job;
+    }
+
+    public async Task<List<ExportJob>> GetJobsAsync()
+    {
+        var list = _jobs.Values.ToList();
+        foreach (var job in list)
+        {
+            await UpdateStatusAsync(job);
+        }
+
+        return list.OrderByDescending(j => j.CreatedAt).ToList();
+    }
+
+    public async Task<bool> DeleteJobAsync(Guid id)
+    {
+        var removed = _jobs.TryRemove(id, out _);
+
+        await _container.DeleteBlobIfExistsAsync($"{id}.csv");
+        await _container.DeleteBlobIfExistsAsync($"{id}.pdf");
+
+        return removed;
+    }
+
+    private async Task UpdateStatusAsync(ExportJob job)
+    {
+        if (job.Status == "completed" || job.Status == "failed")
+            return;
+
+        foreach (var ext in new[] { "csv", "pdf" })
+        {
+            var blobClient = _container.GetBlobClient($"{job.Id}.{ext}");
+            if (await blobClient.ExistsAsync())
+            {
+                job.Status = "completed";
+                job.CompletedAt ??= DateTime.UtcNow;
+                job.DownloadUrl = GenerateSasUrl(blobClient);
+                break;
+            }
+        }
+    }
+
+    private string GenerateSasUrl(BlobClient blobClient)
+    {
+        if (!blobClient.CanGenerateSasUri)
+            return blobClient.Uri.ToString();
+
+        var sas = new BlobSasBuilder
+        {
+            BlobContainerName = blobClient.BlobContainerName,
+            BlobName = blobClient.Name,
+            Resource = "b",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        sas.SetPermissions(BlobSasPermissions.Read);
+        return blobClient.GenerateSasUri(sas).ToString();
+    }
+}

--- a/backend/InvestorCodex.Api/appsettings.Development.json
+++ b/backend/InvestorCodex.Api/appsettings.Development.json
@@ -23,5 +23,11 @@
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
     "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
+  },
+  "Export": {
+    "ServiceBusConnectionString": "",
+    "QueueName": "export-jobs",
+    "BlobConnectionString": "",
+    "ContainerName": "exports"
   }
 }

--- a/backend/InvestorCodex.Api/appsettings.json
+++ b/backend/InvestorCodex.Api/appsettings.json
@@ -29,5 +29,11 @@
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
     "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
+  },
+  "Export": {
+    "ServiceBusConnectionString": "",
+    "QueueName": "export-jobs",
+    "BlobConnectionString": "",
+    "ContainerName": "exports"
   }
 }


### PR DESCRIPTION
## Summary
- flesh out `ExportController` endpoints for creating and tracking export jobs
- add `ExportService` that queues jobs on Azure Service Bus and checks Azure Blob Storage for completed files
- store job metadata in memory
- expose export config via new `ExportSettings`
- include new Service Bus and Blob packages

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a2babb43883328742407c8a0bac95