### PR TITLE
Add settings API and hook admin page

### DIFF
--- a/backend/InvestorCodex.Api/Controllers/SettingsController.cs
+++ b/backend/InvestorCodex.Api/Controllers/SettingsController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using InvestorCodex.Api.Services;
+
+namespace InvestorCodex.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SettingsController : ControllerBase
+{
+    private readonly SettingsStore _store;
+    private readonly ILogger<SettingsController> _logger;
+
+    public SettingsController(SettingsStore store, ILogger<SettingsController> logger)
+    {
+        _store = store;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public ActionResult<IDictionary<string, string>> GetSettings()
+    {
+        return Ok(_store.GetAll());
+    }
+
+    [HttpPost]
+    public IActionResult UpdateSettings([FromBody] Dictionary<string, string> updates)
+    {
+        if (updates == null)
+        {
+            return BadRequest();
+        }
+
+        _logger.LogInformation("Updating settings: {Keys}", string.Join(",", updates.Keys));
+        _store.Update(updates);
+        return Ok(_store.GetAll());
+    }
+}

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -18,6 +18,9 @@ builder.Services.Configure<TwitterAPISettings>(
 builder.Services.Configure<ContextFeedSettings>(
     builder.Configuration.GetSection(ContextFeedSettings.SectionName));
 
+// In-memory store for mutable settings
+builder.Services.AddSingleton<SettingsStore>();
+
 // Add HTTP clients for external services
 builder.Services.AddHttpClient<IApolloService, ApolloService>();
 builder.Services.AddHttpClient<ITwitterService, TwitterService>();

--- a/backend/InvestorCodex.Api/Services/SettingsStore.cs
+++ b/backend/InvestorCodex.Api/Services/SettingsStore.cs
@@ -1,0 +1,33 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Configuration;
+
+namespace InvestorCodex.Api.Services;
+
+public class SettingsStore
+{
+    private readonly ConcurrentDictionary<string, string> _settings = new();
+
+    public SettingsStore(IConfiguration configuration)
+    {
+        // Initialize with configuration values
+        _settings["apollo_api_key"] = configuration["Apollo:ApiKey"] ?? string.Empty;
+        _settings["apollo_base_url"] = configuration["Apollo:BaseUrl"] ?? string.Empty;
+        _settings["twitter_api_key"] = configuration["TwitterAPI:ApiKey"] ?? string.Empty;
+        _settings["twitter_api_secret"] = configuration["TwitterAPI:ApiSecret"] ?? string.Empty;
+        _settings["twitter_bearer_token"] = configuration["TwitterAPI:BearerToken"] ?? string.Empty;
+        _settings["openai_endpoint"] = configuration["AdvantageAI:Url"] ?? string.Empty;
+        _settings["openai_api_key"] = configuration["AdvantageAI:Key"] ?? string.Empty;
+        _settings["openai_model"] = configuration["AdvantageAI:Model"] ?? string.Empty;
+        _settings["db_connection_string"] = configuration.GetConnectionString("DefaultConnection") ?? string.Empty;
+    }
+
+    public IReadOnlyDictionary<string, string> GetAll() => _settings;
+
+    public void Update(Dictionary<string, string> updates)
+    {
+        foreach (var kv in updates)
+        {
+            _settings[kv.Key] = kv.Value ?? string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement backend `/api/settings` endpoints with controller and in-memory store
- register new `SettingsStore` service in API
- load and save configuration through API in admin settings page
- sanitize placeholder values

## Testing
- `dotnet build InvestorCodex.sln` *(fails: command not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a2bac2a8c8332a42a5d4bfc3002f8