### PR TITLE
Add Vector DB and blob storage settings

### DIFF
--- a/backend/InvestorCodex.Api/Configuration/BlobStorageSettings.cs
+++ b/backend/InvestorCodex.Api/Configuration/BlobStorageSettings.cs
@@ -1,0 +1,9 @@
+namespace InvestorCodex.Api.Configuration;
+
+public class BlobStorageSettings
+{
+    public const string SectionName = "BlobStorage";
+
+    public string ConnectionString { get; set; } = string.Empty;
+    public string Container { get; set; } = string.Empty;
+}

--- a/backend/InvestorCodex.Api/Configuration/VectorDbSettings.cs
+++ b/backend/InvestorCodex.Api/Configuration/VectorDbSettings.cs
@@ -1,0 +1,10 @@
+namespace InvestorCodex.Api.Configuration;
+
+public class VectorDbSettings
+{
+    public const string SectionName = "VectorDb";
+
+    public string Endpoint { get; set; } = string.Empty;
+    public string Index { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+}

--- a/backend/InvestorCodex.Api/Controllers/HealthController.cs
+++ b/backend/InvestorCodex.Api/Controllers/HealthController.cs
@@ -12,19 +12,27 @@ public class HealthController : ControllerBase
     private readonly AdvantageAISettings _advantageAISettings;
     private readonly ApolloSettings _apolloSettings;
     private readonly TwitterAPISettings _twitterSettings;
+    private readonly VectorDbSettings _vectorDbSettings;
+    private readonly BlobStorageSettings _blobStorageSettings;
     private readonly IConfiguration _configuration;
 
     public HealthController(
         IOptions<AdvantageAISettings> advantageAISettings,
         IOptions<ApolloSettings> apolloSettings,
         IOptions<TwitterAPISettings> twitterSettings,
+        IOptions<VectorDbSettings> vectorDbSettings,
+        IOptions<BlobStorageSettings> blobStorageSettings,
         IConfiguration configuration)
     {
         _advantageAISettings = advantageAISettings.Value;
         _apolloSettings = apolloSettings.Value;
         _twitterSettings = twitterSettings.Value;
+        _vectorDbSettings = vectorDbSettings.Value;
+        _blobStorageSettings = blobStorageSettings.Value;
         _configuration = configuration;
-    }    [HttpGet]
+    }
+
+    [HttpGet]
     public async Task<ActionResult<object>> Get()
     {
         var databaseStatus = await CheckDatabaseConnectionAsync();
@@ -40,7 +48,9 @@ public class HealthController : ControllerBase
                 Database = databaseStatus,
                 AzureOpenAI = !string.IsNullOrEmpty(_advantageAISettings.Key) && !string.IsNullOrEmpty(_advantageAISettings.Url) ? "Configured" : "Not Configured",
                 Apollo = !string.IsNullOrEmpty(_apolloSettings.ApiKey) ? "Configured" : "Not Configured",
-                Twitter = !string.IsNullOrEmpty(_twitterSettings.BearerToken) ? "Configured" : "Not Configured"
+                Twitter = !string.IsNullOrEmpty(_twitterSettings.BearerToken) ? "Configured" : "Not Configured",
+                VectorDb = !string.IsNullOrEmpty(_vectorDbSettings.Endpoint) && !string.IsNullOrEmpty(_vectorDbSettings.Index) ? "Configured" : "Not Configured",
+                BlobStorage = !string.IsNullOrEmpty(_blobStorageSettings.ConnectionString) && !string.IsNullOrEmpty(_blobStorageSettings.Container) ? "Configured" : "Not Configured"
             }
         });
     }

--- a/backend/InvestorCodex.Api/Controllers/SettingsController.cs
+++ b/backend/InvestorCodex.Api/Controllers/SettingsController.cs
@@ -1,0 +1,51 @@
+using InvestorCodex.Api.Configuration;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace InvestorCodex.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SettingsController : ControllerBase
+{
+    private static VectorDbSettings _vectorDb = new();
+    private static BlobStorageSettings _blobStorage = new();
+    private readonly ILogger<SettingsController> _logger;
+
+    public SettingsController(IOptions<VectorDbSettings> vectorDb,
+                              IOptions<BlobStorageSettings> blobStorage,
+                              ILogger<SettingsController> logger)
+    {
+        if (string.IsNullOrEmpty(_vectorDb.Endpoint))
+        {
+            _vectorDb = vectorDb.Value;
+        }
+        if (string.IsNullOrEmpty(_blobStorage.ConnectionString))
+        {
+            _blobStorage = blobStorage.Value;
+        }
+        _logger = logger;
+    }
+
+    [HttpGet("vector-db")]
+    public ActionResult<VectorDbSettings> GetVectorDb() => Ok(_vectorDb);
+
+    [HttpPost("vector-db")]
+    public ActionResult SaveVectorDb([FromBody] VectorDbSettings settings)
+    {
+        _vectorDb = settings;
+        _logger.LogInformation("Vector DB settings updated");
+        return Ok();
+    }
+
+    [HttpGet("blob-storage")]
+    public ActionResult<BlobStorageSettings> GetBlobStorage() => Ok(_blobStorage);
+
+    [HttpPost("blob-storage")]
+    public ActionResult SaveBlobStorage([FromBody] BlobStorageSettings settings)
+    {
+        _blobStorage = settings;
+        _logger.LogInformation("Blob storage settings updated");
+        return Ok();
+    }
+}

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -17,6 +17,10 @@ builder.Services.Configure<TwitterAPISettings>(
     builder.Configuration.GetSection(TwitterAPISettings.SectionName));
 builder.Services.Configure<ContextFeedSettings>(
     builder.Configuration.GetSection(ContextFeedSettings.SectionName));
+builder.Services.Configure<VectorDbSettings>(
+    builder.Configuration.GetSection(VectorDbSettings.SectionName));
+builder.Services.Configure<BlobStorageSettings>(
+    builder.Configuration.GetSection(BlobStorageSettings.SectionName));
 
 // Add HTTP clients for external services
 builder.Services.AddHttpClient<IApolloService, ApolloService>();

--- a/backend/InvestorCodex.Api/appsettings.Development.json
+++ b/backend/InvestorCodex.Api/appsettings.Development.json
@@ -23,5 +23,14 @@
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
     "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
+  },
+  "VectorDb": {
+    "Endpoint": "https://my-vector-db.ai/",
+    "Index": "companies",
+    "Key": "changeme"
+  },
+  "BlobStorage": {
+    "ConnectionString": "UseDevelopmentStorage=true",
+    "Container": "exports"
   }
 }

--- a/backend/InvestorCodex.Api/appsettings.json
+++ b/backend/InvestorCodex.Api/appsettings.json
@@ -29,5 +29,14 @@
   "ContextFeeds": {
     "vc-latest": "https://mcp.investorcodex.ai/context?id=vc-latest",
     "investor-weekly": "https://mcp.investorcodex.ai/context?id=investor-weekly"
+  },
+  "VectorDb": {
+    "Endpoint": "https://my-vector-db.ai/",
+    "Index": "companies",
+    "Key": "changeme"
+  },
+  "BlobStorage": {
+    "ConnectionString": "UseDevelopmentStorage=true",
+    "Container": "exports"
   }
 }

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -158,6 +158,66 @@ export default function SettingsPage() {
         },
       ],
     },
+    {
+      name: 'Vector DB',
+      icon: <CloudIcon className="h-6 w-6" />,
+      description: 'Embeddings and similarity search storage',
+      status: 'disconnected',
+      lastTested: 'Never',
+      fields: [
+        {
+          key: 'vectordb_endpoint',
+          label: 'Endpoint',
+          type: 'url',
+          value: '',
+          placeholder: 'https://my-vector-db.ai/',
+          required: true,
+        },
+        {
+          key: 'vectordb_index',
+          label: 'Index',
+          type: 'text',
+          value: '',
+          placeholder: 'companies',
+          required: true,
+        },
+        {
+          key: 'vectordb_key',
+          label: 'API Key',
+          type: 'password',
+          value: '',
+          placeholder: 'Key for Vector DB',
+          required: true,
+          masked: true,
+        },
+      ],
+    },
+    {
+      name: 'Blob Storage',
+      icon: <CloudIcon className="h-6 w-6" />,
+      description: 'Used for exported files and documents',
+      status: 'disconnected',
+      lastTested: 'Never',
+      fields: [
+        {
+          key: 'blob_connection',
+          label: 'Connection String',
+          type: 'password',
+          value: '',
+          placeholder: 'Azure Storage connection string',
+          required: true,
+          masked: true,
+        },
+        {
+          key: 'blob_container',
+          label: 'Container',
+          type: 'text',
+          value: '',
+          placeholder: 'exports',
+          required: true,
+        },
+      ],
+    },
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- expand admin settings page to configure Vector DB and Blob Storage
- introduce `VectorDbSettings` and `BlobStorageSettings` classes
- expose new API controller for updating settings
- wire settings into program startup and health check
- include config sections in appsettings

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a2bc479e483329124e33f902a499a