### PR TITLE
Update service registration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ The project is at an early stage and currently only includes minimal scaffolding
 ## Configuration
 
 The API expects several credentials to be supplied via environment variables or
-your preferred secrets manager. The following variables are required:
+your preferred secrets manager. Values map to `appsettings.json` sections using
+double underscores (`__`). The most common variables are shown below:
 
 ```
+CONNECTIONSTRINGS__DEFAULTCONNECTION=<PostgreSQL connection string>
+EMBEDDINGSERVICE__BASEURL=<URL for the embedding service>
 ADVANTAGEAI__URL=<Azure OpenAI endpoint>
 ADVANTAGEAI__KEY=<Azure OpenAI key>
 ADVANTAGEAI__MODEL=<Model name>
@@ -28,7 +31,12 @@ APOLLO__BASEURL=<Apollo base URL>
 TWITTERAPI__APIKEY=<Twitter API key>
 TWITTERAPI__APISECRET=<Twitter API secret>
 TWITTERAPI__BEARERTOKEN=<Twitter bearer token>
+VECTORDB__ENDPOINT=<Vector DB endpoint>
+VECTORDB__INDEX=<Vector index name>
+VECTORDB__KEY=<Vector DB key>
+BLOBSTORAGE__CONNECTIONSTRING=<Azure Blob Storage connection string>
+BLOBSTORAGE__CONTAINER=<Target storage container>
 ```
 
-Ensure these are set before running the backend project.
+Set these variables before running any backend services.
 

--- a/backend/InvestorCodex.Api/Program.cs
+++ b/backend/InvestorCodex.Api/Program.cs
@@ -50,7 +50,6 @@ builder.Services.AddScoped<IUserRepository, UserRepository>();
 
 // Add external API services
 builder.Services.AddScoped<IApolloService, ApolloService>();
-builder.Services.AddScoped<ITwitterService, TwitterService>();
 builder.Services.AddScoped<IContextFeedService, ContextFeedService>();
 builder.Services.AddScoped<ISignalDetectionService, SignalDetectionService>();
 builder.Services.AddSingleton<IExportJobService, ExportJobService>();


### PR DESCRIPTION
## Summary
- remove redundant Twitter service registration
- document common environment variables

## Testing
- `dotnet build InvestorCodex.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ad6f72e488332b18679f4b5a8e7d0