### PR TITLE
Add tests for GetHighConfidenceSignalsAsync

### DIFF
--- a/InvestorCodex.sln
+++ b/InvestorCodex.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvestorCodex.Api", "backen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvestorCodex.SyncService", "backend\InvestorCodex.SyncService\InvestorCodex.SyncService.csproj", "{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvestorCodex.Api.Tests", "backend\InvestorCodex.Api.Tests\InvestorCodex.Api.Tests.csproj", "{7F09827E-2F28-4559-80E4-F5E80BD2AC6C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,9 +18,13 @@ Global
 		{1B2C3D4E-5F6A-7B8C-9D0E-1F2A3B4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B2C3D4E-5F6A-7B8C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B2C3D4E-5F6A-7B8C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {7F09827E-2F28-4559-80E4-F5E80BD2AC6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7F09827E-2F28-4559-80E4-F5E80BD2AC6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7F09827E-2F28-4559-80E4-F5E80BD2AC6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7F09827E-2F28-4559-80E4-F5E80BD2AC6C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/backend/InvestorCodex.Api.Tests/InvestorCodex.Api.Tests.csproj
+++ b/backend/InvestorCodex.Api.Tests/InvestorCodex.Api.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\InvestorCodex.Api\InvestorCodex.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/InvestorCodex.Api.Tests/SignalDetectionServiceTests.cs
+++ b/backend/InvestorCodex.Api.Tests/SignalDetectionServiceTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using InvestorCodex.Api.Configuration;
+using InvestorCodex.Api.Data;
+using InvestorCodex.Api.Models;
+using InvestorCodex.Api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace InvestorCodex.Api.Tests;
+
+public class SignalDetectionServiceTests
+{
+    private static SignalDetectionService CreateService(ISignalRepository repo)
+    {
+        var twitter = new Mock<ITwitterService>().Object;
+        var context = new Mock<IContextFeedService>().Object;
+        var companyRepo = new Mock<ICompanyRepository>().Object;
+        var httpClient = new HttpClient();
+        var options = Options.Create(new AdvantageAISettings());
+        var logger = NullLogger<SignalDetectionService>.Instance;
+        return new SignalDetectionService(twitter, context, repo, companyRepo, httpClient, options, logger);
+    }
+
+    [Fact]
+    public async Task GetHighConfidenceSignalsAsync_ReturnsSignals_WhenDataExists()
+    {
+        // Arrange
+        var signals = new List<Signal>
+        {
+            new Signal
+            {
+                Id = Guid.NewGuid(),
+                Type = "Funding",
+                Source = "techcrunch",
+                Confidence = 0.8f,
+                CreatedAt = DateTime.UtcNow
+            },
+            new Signal
+            {
+                Id = Guid.NewGuid(),
+                Type = "Acquisition",
+                Source = "twitter",
+                Confidence = 0.9f,
+                CreatedAt = DateTime.UtcNow
+            }
+        };
+
+        var repoMock = new Mock<ISignalRepository>();
+        repoMock.Setup(r => r.GetSignalsAsync(It.IsAny<int>(), It.IsAny<int>(), null, null, null, null))
+            .ReturnsAsync((signals.AsEnumerable(), signals.Count));
+
+        var service = CreateService(repoMock.Object);
+
+        // Act
+        var result = await service.GetHighConfidenceSignalsAsync();
+
+        // Assert
+        Assert.Equal(signals.Count, result.Count);
+        Assert.All(signals, s => Assert.Contains(result, r => r.Id == s.Id));
+    }
+
+    [Fact]
+    public async Task GetHighConfidenceSignalsAsync_ReturnsEmpty_WhenNoSignals()
+    {
+        // Arrange
+        var repoMock = new Mock<ISignalRepository>();
+        repoMock.Setup(r => r.GetSignalsAsync(It.IsAny<int>(), It.IsAny<int>(), null, null, null, null))
+            .ReturnsAsync((Enumerable.Empty<Signal>(), 0));
+
+        var service = CreateService(repoMock.Object);
+
+        // Act
+        var result = await service.GetHighConfidenceSignalsAsync();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetHighConfidenceSignalsAsync_ReturnsEmpty_WhenRepositoryFails()
+    {
+        // Arrange
+        var repoMock = new Mock<ISignalRepository>();
+        repoMock.Setup(r => r.GetSignalsAsync(It.IsAny<int>(), It.IsAny<int>(), null, null, null, null))
+            .ThrowsAsync(new Exception("table missing"));
+
+        var service = CreateService(repoMock.Object);
+
+        // Act
+        var result = await service.GetHighConfidenceSignalsAsync();
+
+        // Assert
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `InvestorCodex.Api.Tests` project
- verify `GetHighConfidenceSignalsAsync` returns records when data exists
- ensure empty and missing table scenarios return empty lists
- include new test project in solution

## Testing
- `dotnet test InvestorCodex.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ad6f7fcac8332982dffd925dda28c